### PR TITLE
style(dashboard): maquetado silabo (solo UI, sin back)

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -10,17 +10,23 @@
     "preview": "vite preview --port 5002 --strictPort"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.13",
+    "@tanstack/react-query": "^5.90.2",
+    "axios": "^1.12.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.1",
+    "react-hook-form": "^7.63.0",
+    "react-router-dom": "^7.9.3",
     "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.13"
+    "tailwindcss": "^4.1.13",
+    "use-debounce": "^10.0.6",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -4,6 +4,9 @@ import Home from "./components/pages/Home";
 import Subjects from "./components/pages/Subjects";
 import CreateCourse from "./components/pages/CreateCourse";
 
+// 🔥 Importamos tu nueva página
+import SyllabusPage from "./pages/syllabus/[id]";
+
 export default function App() {
   return (
     <Router>
@@ -29,6 +32,16 @@ export default function App() {
           element={
             <Layout title="Crear nuevo curso">
               <CreateCourse />
+            </Layout>
+          }
+        />
+
+        {/* 🚀 Nueva ruta para el editor de sílabos */}
+        <Route
+          path="/syllabus/:id"
+          element={
+            <Layout title="Editar sílabo">
+              <SyllabusPage />
             </Layout>
           }
         />

--- a/apps/dashboard/src/components/SyllabusWizard.tsx
+++ b/apps/dashboard/src/components/SyllabusWizard.tsx
@@ -1,0 +1,34 @@
+﻿import StepSumilla from "./steps/StepSumilla";
+import StepWeeks from "./steps/StepWeeks"; // 👈 nuevo paso
+import { useState } from "react";
+
+export default function SyllabusWizard({ id }: { id: string }) {
+  const [step, setStep] = useState(0);
+
+  const steps = [
+    { title: "Sumilla", node: <StepSumilla /> },
+    { title: "Unidades", node: <StepWeeks /> }, // 👈 agregado
+  ];
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">Editar Sílabos (id: {id})</h1>
+
+      <div className="flex gap-2 mb-6">
+        {steps.map((s, i) => (
+          <button
+            key={s.title}
+            onClick={() => setStep(i)}
+            className={`w-10 h-10 rounded-full border flex items-center justify-center ${
+              step === i ? "bg-black text-white" : "bg-white"
+            }`}
+          >
+            {i + 1}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-6">{steps[step].node}</div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/SyllabusWizard.tsx
+++ b/apps/dashboard/src/components/SyllabusWizard.tsx
@@ -1,34 +1,61 @@
-﻿import StepSumilla from "./steps/StepSumilla";
-import StepWeeks from "./steps/StepWeeks"; // 👈 nuevo paso
-import { useState } from "react";
+﻿import { useState } from "react";
+import Stepper from "./ui/Stepper";
+import StepSumilla from "./steps/StepSumilla";
+import StepWeeks from "./steps/StepWeeks";
+import StepActividades from "./steps/StepActividades";
+import StepBibliografia from "./steps/StepBibliografia";
+import StepElectronicas from "./steps/StepElectronicas";
 
 export default function SyllabusWizard({ id }: { id: string }) {
   const [step, setStep] = useState(0);
 
   const steps = [
     { title: "Sumilla", node: <StepSumilla /> },
-    { title: "Unidades", node: <StepWeeks /> }, // 👈 agregado
+    { title: "Unidades / Semanas", node: <StepWeeks /> },
+    { title: "Actividades", node: <StepActividades /> },
+    { title: "Bibliográficas", node: <StepBibliografia /> },
+    { title: "Electrónicas", node: <StepElectronicas /> },
   ];
 
   return (
-    <div className="max-w-5xl mx-auto p-6">
-      <h1 className="text-2xl font-semibold mb-4">Editar Sílabos (id: {id})</h1>
+    <div className="max-w-6xl mx-auto p-6">
+      <h1 className="text-3xl font-semibold">Editar Sílabo (id: {id})</h1>
+      <Stepper step={step} total={steps.length} />
 
-      <div className="flex gap-2 mb-6">
-        {steps.map((s, i) => (
-          <button
-            key={s.title}
-            onClick={() => setStep(i)}
-            className={`w-10 h-10 rounded-full border flex items-center justify-center ${
-              step === i ? "bg-black text-white" : "bg-white"
-            }`}
-          >
-            {i + 1}
-          </button>
-        ))}
+      <div className="mb-6 border rounded-xl p-4 bg-white">
+        {steps[step].node}
       </div>
 
-      <div className="mb-6">{steps[step].node}</div>
+      <div className="flex justify-between">
+        <button
+          onClick={() => setStep((v) => Math.max(0, v - 1))}
+          className="px-4 py-2 border rounded-lg disabled:opacity-50"
+          disabled={step === 0}
+        >
+          Atrás
+        </button>
+        <div className="flex gap-2">
+          {steps.map((s, i) => (
+            <button
+              key={s.title}
+              onClick={() => setStep(i)}
+              className={`w-10 h-10 rounded-full border flex items-center justify-center ${
+                step === i ? "bg-black text-white" : "bg-white"
+              }`}
+              title={s.title}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => setStep((v) => Math.min(steps.length - 1, v + 1))}
+          className="px-4 py-2 border rounded-lg disabled:opacity-50"
+          disabled={step === steps.length - 1}
+        >
+          Siguiente
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/components/layout/Sidebar.tsx
+++ b/apps/dashboard/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, BookOpen } from "lucide-react";
+import { Home, BookOpen, FileText } from "lucide-react";
 import { Link } from "react-router-dom";
 import usmpLogo from "../../assets/Logo_FIA.png";
 
@@ -27,6 +27,15 @@ export default function Sidebar() {
               className="flex items-center gap-3 p-2 rounded hover:bg-gray-700"
             >
               <BookOpen size={18} /> Asignaturas
+            </Link>
+          </li>
+          {/* 🚀 Nuevo acceso directo para tu editor de sílabo */}
+          <li>
+            <Link
+              to="/syllabus/demo"
+              className="flex items-center gap-3 p-2 rounded hover:bg-gray-700"
+            >
+              <FileText size={18} /> Editar sílabo
             </Link>
           </li>
         </ul>

--- a/apps/dashboard/src/components/steps/StepActividades.tsx
+++ b/apps/dashboard/src/components/steps/StepActividades.tsx
@@ -1,0 +1,138 @@
+import { useMemo, useState } from "react";
+
+type Item = { id: string; t: string; h: number }; // h = horas
+const HORAS_TOTALES = 120;
+
+export default function StepActividades() {
+  const [week, setWeek] = useState("Semana 1");
+  const [items, setItems] = useState<Item[]>([
+    { id: crypto.randomUUID(), t: "Trabajo grupal en el proyecto", h: 2 },
+    { id: crypto.randomUUID(), t: "Expone el proyecto final", h: 2 },
+    { id: crypto.randomUUID(), t: "Reunión de coordinación diaria", h: 3 },
+    { id: crypto.randomUUID(), t: "Crea informe final de proyecto", h: 3 },
+  ]);
+  const [newTitle, setNewTitle] = useState("");
+  const [newHours, setNewHours] = useState(1);
+
+  const usadas = useMemo(() => items.reduce((s, i) => s + i.h, 0), [items]);
+  const restantes = Math.max(0, HORAS_TOTALES - usadas);
+
+  function addItem() {
+    if (!newTitle.trim()) return;
+    setItems((prev) => [
+      ...prev,
+      { id: crypto.randomUUID(), t: newTitle.trim(), h: Math.max(1, newHours) },
+    ]);
+    setNewTitle("");
+    setNewHours(1);
+  }
+
+  function removeItem(id: string) {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  function setHours(id: string, h: number) {
+    setItems((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, h: Math.max(1, h) } : i)),
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-xl font-bold">4. Actividades de Aprendizaje</h2>
+
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <label className="block text-sm mb-1">Selecciona una semana</label>
+          <select
+            className="rounded-full px-4 py-2 border"
+            value={week}
+            onChange={(e) => setWeek(e.target.value)}
+          >
+            {Array.from({ length: 16 }, (_, i) => `Semana ${i + 1}`).map(
+              (w) => (
+                <option key={w}>{w}</option>
+              ),
+            )}
+          </select>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full px-4 py-2 bg-black text-white">
+          Horas disponibles: {restantes}
+        </div>
+      </div>
+
+      {/* Lista editable */}
+      <div className="rounded-2xl border p-4 space-y-3">
+        {items.map((it) => (
+          <div
+            key={it.id}
+            className="flex items-center gap-3 bg-gray-100 rounded-full px-4 py-2"
+          >
+            <input
+              className="flex-1 bg-transparent outline-none"
+              value={it.t}
+              onChange={(e) =>
+                setItems((prev) =>
+                  prev.map((x) =>
+                    x.id === it.id ? { ...x, t: e.target.value } : x,
+                  ),
+                )
+              }
+            />
+            <div className="flex items-center gap-2">
+              <button
+                className="px-2 rounded-full border"
+                onClick={() => setHours(it.id, Math.max(1, it.h - 1))}
+                disabled={it.h <= 1}
+              >
+                −
+              </button>
+              <span className="px-3 py-1 rounded-full bg-gray-300">
+                {it.h} h
+              </span>
+              <button
+                className="px-2 rounded-full border"
+                onClick={() => setHours(it.id, it.h + 1)}
+                disabled={usadas >= HORAS_TOTALES}
+              >
+                +
+              </button>
+            </div>
+            <button
+              aria-label="remove"
+              className="w-8 h-8 rounded-full border flex items-center justify-center"
+              onClick={() => removeItem(it.id)}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+
+        {/* añadir nueva */}
+        <div className="flex items-center gap-3 pt-2">
+          <input
+            className="flex-1 border rounded-md px-3 py-2"
+            placeholder="Nueva actividad…"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+          />
+          <input
+            type="number"
+            min={1}
+            className="w-24 border rounded-md px-3 py-2"
+            value={newHours}
+            onChange={(e) => setNewHours(Number(e.target.value || 1))}
+          />
+          <button
+            className="px-3 py-2 rounded-md border"
+            onClick={addItem}
+            disabled={!newTitle.trim()}
+          >
+            Añadir
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/steps/StepBibliografia.tsx
+++ b/apps/dashboard/src/components/steps/StepBibliografia.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+
+type Ref = { id: string; autor: string; anio: string; titulo: string };
+
+export default function StepBibliografia() {
+  const [refs, setRefs] = useState<Ref[]>([
+    {
+      id: crypto.randomUUID(),
+      autor: "Chandrasekara, C., & Herath, P.",
+      anio: "(2021).",
+      titulo: "Hands-on GitHub Actions…",
+    },
+    {
+      id: crypto.randomUUID(),
+      autor: "Guijarro Olivares, J.…",
+      anio: "(2019).",
+      titulo: "DevOps y seguridad cloud…",
+    },
+  ]);
+  const [nuevo, setNuevo] = useState<Ref>({
+    id: "",
+    autor: "",
+    anio: "",
+    titulo: "",
+  });
+
+  function addRef() {
+    if (!nuevo.autor.trim() || !nuevo.titulo.trim()) return;
+    setRefs((prev) => [...prev, { ...nuevo, id: crypto.randomUUID() }]);
+    setNuevo({ id: "", autor: "", anio: "", titulo: "" });
+  }
+
+  function removeRef(id: string) {
+    setRefs((prev) => prev.filter((r) => r.id !== id));
+  }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-xl font-bold">8.1. Bibliográficas</h2>
+      <div className="rounded-2xl border p-4 space-y-3">
+        {refs.map((r) => (
+          <div key={r.id} className="grid md:grid-cols-3 gap-3 items-center">
+            <input
+              className="bg-gray-100 rounded-full px-4 py-2"
+              value={r.autor}
+              onChange={(e) =>
+                setRefs((prev) =>
+                  prev.map((x) =>
+                    x.id === r.id ? { ...x, autor: e.target.value } : x,
+                  ),
+                )
+              }
+            />
+            <input
+              className="bg-gray-100 rounded-full px-4 py-2 text-center"
+              value={r.anio}
+              onChange={(e) =>
+                setRefs((prev) =>
+                  prev.map((x) =>
+                    x.id === r.id ? { ...x, anio: e.target.value } : x,
+                  ),
+                )
+              }
+            />
+            <div className="flex items-center gap-2">
+              <input
+                className="flex-1 bg-gray-100 rounded-full px-4 py-2"
+                value={r.titulo}
+                onChange={(e) =>
+                  setRefs((prev) =>
+                    prev.map((x) =>
+                      x.id === r.id ? { ...x, titulo: e.target.value } : x,
+                    ),
+                  )
+                }
+              />
+              <button
+                className="w-8 h-8 rounded-full border flex items-center justify-center"
+                onClick={() => removeRef(r.id)}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {/* nueva referencia */}
+        <div className="grid md:grid-cols-3 gap-3 items-center pt-3">
+          <input
+            className="bg-white border rounded-full px-4 py-2"
+            placeholder="Autor(es)…"
+            value={nuevo.autor}
+            onChange={(e) => setNuevo((s) => ({ ...s, autor: e.target.value }))}
+          />
+          <input
+            className="bg-white border rounded-full px-4 py-2 text-center"
+            placeholder="(Año)"
+            value={nuevo.anio}
+            onChange={(e) => setNuevo((s) => ({ ...s, anio: e.target.value }))}
+          />
+          <div className="flex items-center gap-2">
+            <input
+              className="flex-1 bg-white border rounded-full px-4 py-2"
+              placeholder="Título…"
+              value={nuevo.titulo}
+              onChange={(e) =>
+                setNuevo((s) => ({ ...s, titulo: e.target.value }))
+              }
+            />
+            <button className="px-3 py-2 rounded-full border" onClick={addRef}>
+              ＋
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/steps/StepElectronicas.tsx
+++ b/apps/dashboard/src/components/steps/StepElectronicas.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+
+type Item = { id: string; cita: string; url: string };
+
+export default function StepElectronicas() {
+  const [items, setItems] = useState<Item[]>([
+    {
+      id: crypto.randomUUID(),
+      cita: "AWS. (2023)…",
+      url: "https://aws.amazon.com/es/education/awseducate/",
+    },
+    {
+      id: crypto.randomUUID(),
+      cita: "Microsoft. (2023a)…",
+      url: "https://azure.microsoft.com/es-es/get-started/azure-portal",
+    },
+  ]);
+
+  const [nuevo, setNuevo] = useState<Item>({ id: "", cita: "", url: "" });
+
+  function addItem() {
+    if (!nuevo.cita.trim() || !nuevo.url.trim()) return;
+    setItems((prev) => [...prev, { ...nuevo, id: crypto.randomUUID() }]);
+    setNuevo({ id: "", cita: "", url: "" });
+  }
+  function removeItem(id: string) {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-xl font-bold">8.2. Electrónicas</h2>
+      <div className="rounded-2xl border p-4 space-y-3">
+        {items.map((it) => (
+          <div key={it.id} className="grid md:grid-cols-2 gap-3 items-center">
+            <input
+              className="bg-gray-100 rounded-full px-4 py-2"
+              value={it.cita}
+              onChange={(e) =>
+                setItems((prev) =>
+                  prev.map((x) =>
+                    x.id === it.id ? { ...x, cita: e.target.value } : x,
+                  ),
+                )
+              }
+            />
+            <div className="flex items-center gap-2">
+              <input
+                className="flex-1 bg-gray-100 rounded-full px-4 py-2"
+                value={it.url}
+                onChange={(e) =>
+                  setItems((prev) =>
+                    prev.map((x) =>
+                      x.id === it.id ? { ...x, url: e.target.value } : x,
+                    ),
+                  )
+                }
+              />
+              <a
+                href={it.url}
+                target="_blank"
+                className="px-3 py-1 rounded-full border"
+              >
+                Abrir
+              </a>
+              <button
+                className="w-8 h-8 rounded-full border flex items-center justify-center"
+                onClick={() => removeItem(it.id)}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {/* nuevo */}
+        <div className="grid md:grid-cols-2 gap-3 items-center pt-3">
+          <input
+            className="bg-white border rounded-full px-4 py-2"
+            placeholder="Cita…"
+            value={nuevo.cita}
+            onChange={(e) => setNuevo((s) => ({ ...s, cita: e.target.value }))}
+          />
+          <div className="flex items-center gap-2">
+            <input
+              className="flex-1 bg-white border rounded-full px-4 py-2"
+              placeholder="URL…"
+              value={nuevo.url}
+              onChange={(e) => setNuevo((s) => ({ ...s, url: e.target.value }))}
+            />
+            <button className="px-3 py-2 rounded-full border" onClick={addItem}>
+              ＋
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/steps/StepSumilla.tsx
+++ b/apps/dashboard/src/components/steps/StepSumilla.tsx
@@ -1,22 +1,33 @@
 ﻿export default function StepSumilla() {
   return (
-    <div className="space-y-3">
-      <h2 className="text-lg font-semibold">2. Sumilla</h2>
-      <textarea
-        className="w-full border rounded p-3"
-        rows={6}
-        placeholder="Es de carácter aplicativo..."
-      />
-      <h3 className="text-lg font-semibold">2. Unidades</h3>
-      <div className="grid grid-cols-2 gap-4">
-        <input className="border rounded p-2" placeholder="Unidad I: Título" />
-        <input className="border rounded p-2" placeholder="Unidad II: Título" />
-        <input
-          className="border rounded p-2"
-          placeholder="Unidad III: Título"
-        />
-        <input className="border rounded p-2" placeholder="Unidad IV: Título" />
+    <section className="space-y-3">
+      <h2 className="text-xl font-bold">
+        2. Sumilla <span title="ayuda">ℹ️</span>
+      </h2>
+      <div className="rounded-xl border border-gray-300 p-5">
+        <p className="leading-7 text-gray-800">
+          Es de carácter aplicativo; permitirá al estudiante desarrollar su
+          capacidad para resolver una situación problemática real a través del
+          desarrollo de un proyecto altamente innovador…
+        </p>
       </div>
-    </div>
+      <h2 className="text-xl font-bold mt-6">
+        2. Unidades <span title="ayuda">ℹ️</span>
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[
+          "Unidad I: Título",
+          "Unidad II: Título",
+          "Unidad III: Título",
+          "Unidad IV: Título",
+        ].map((txt) => (
+          <input
+            key={txt}
+            className="border rounded-md px-3 py-2"
+            placeholder={txt}
+          />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/apps/dashboard/src/components/steps/StepSumilla.tsx
+++ b/apps/dashboard/src/components/steps/StepSumilla.tsx
@@ -1,0 +1,22 @@
+﻿export default function StepSumilla() {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold">2. Sumilla</h2>
+      <textarea
+        className="w-full border rounded p-3"
+        rows={6}
+        placeholder="Es de carácter aplicativo..."
+      />
+      <h3 className="text-lg font-semibold">2. Unidades</h3>
+      <div className="grid grid-cols-2 gap-4">
+        <input className="border rounded p-2" placeholder="Unidad I: Título" />
+        <input className="border rounded p-2" placeholder="Unidad II: Título" />
+        <input
+          className="border rounded p-2"
+          placeholder="Unidad III: Título"
+        />
+        <input className="border rounded p-2" placeholder="Unidad IV: Título" />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/steps/StepWeeks.tsx
+++ b/apps/dashboard/src/components/steps/StepWeeks.tsx
@@ -1,0 +1,121 @@
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+const UNIDADES = [
+  "I. DISEÑO DE SOLUCIONES INNOVADORAS",
+  "II. GESTIÓN DE PROYECTOS Y APLICACIONES MODERNAS",
+  "III. INTEGRACIÓN Y ENTREGA CONTINUA",
+  "IV. PRESENTACIÓN Y EVALUACIÓN DE RESULTADOS",
+];
+
+const SEMANAS = Array.from({ length: 16 }, (_, i) => `Semana ${i + 1}`);
+
+function Counter({ value, max = 400 }: { value: string; max?: number }) {
+  const count = useMemo(() => value.length, [value]);
+  return (
+    <span className="absolute right-3 bottom-2 text-gray-500 text-sm">
+      {count}/{max}
+    </span>
+  );
+}
+
+export default function StepWeeks() {
+  const [unidad, setUnidad] = useState(UNIDADES[0]);
+  const [semana, setSemana] = useState(SEMANAS[0]);
+  const [conceptual, setConceptual] = useState(
+    "El taller y sus objetivos generales. El modelo de trabajo. Planteamiento del problema. El pensamiento de diseño y sus técnicas. Las necesidades del público objetivo y del entorno para entender a los usuarios.",
+  );
+  const [procedimental, setProcedimental] = useState(
+    "El taller y sus objetivos generales. El modelo de trabajo. Planteamiento del problema. El pensamiento de diseño y sus técnicas. Las necesidades del público objetivo y del entorno para entender a los usuarios.",
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* 4. Unidades */}
+      <div className="space-y-3">
+        <h3 className="text-xl font-semibold tracking-tight">4. Unidades</h3>
+
+        <div className="relative">
+          <select
+            value={unidad}
+            onChange={(e) => setUnidad(e.target.value)}
+            className="
+              w-full appearance-none border rounded-xl px-4 py-4 pr-12
+              text-lg text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-300
+            "
+          >
+            {UNIDADES.map((u) => (
+              <option key={u} value={u}>{`Unidad: ${u}`}</option>
+            ))}
+          </select>
+
+          <ChevronDown
+            size={20}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none"
+          />
+        </div>
+      </div>
+
+      {/* 4. Semanas */}
+      <div className="space-y-3">
+        <h3 className="text-xl font-semibold tracking-tight">4. Semanas</h3>
+        <p className="text-sm text-gray-600">Selecciona una semana</p>
+
+        <div className="relative inline-block">
+          <select
+            value={semana}
+            onChange={(e) => setSemana(e.target.value)}
+            className="
+              appearance-none rounded-full px-5 py-2.5 pr-12
+              bg-black text-white font-semibold
+              focus:outline-none
+            "
+          >
+            {SEMANAS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size={18}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-white pointer-events-none"
+          />
+        </div>
+      </div>
+
+      {/* Textareas */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="space-y-2">
+          <h4 className="font-semibold text-lg">Contenidos conceptuales</h4>
+          <div className="relative">
+            <textarea
+              rows={9}
+              maxLength={400}
+              value={conceptual}
+              onChange={(e) => setConceptual(e.target.value)}
+              className="w-full border rounded-xl p-4 text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              placeholder="El taller y sus objetivos generales..."
+            />
+            <Counter value={conceptual} />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <h4 className="font-semibold text-lg">Contenidos Procedimentales</h4>
+          <div className="relative">
+            <textarea
+              rows={9}
+              maxLength={400}
+              value={procedimental}
+              onChange={(e) => setProcedimental(e.target.value)}
+              className="w-full border rounded-xl p-4 text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              placeholder="El taller y sus objetivos generales..."
+            />
+            <Counter value={procedimental} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/steps/StepWeeks.tsx
+++ b/apps/dashboard/src/components/steps/StepWeeks.tsx
@@ -1,121 +1,95 @@
 import { useMemo, useState } from "react";
-import { ChevronDown } from "lucide-react";
 
-const UNIDADES = [
-  "I. DISEÑO DE SOLUCIONES INNOVADORAS",
-  "II. GESTIÓN DE PROYECTOS Y APLICACIONES MODERNAS",
-  "III. INTEGRACIÓN Y ENTREGA CONTINUA",
-  "IV. PRESENTACIÓN Y EVALUACIÓN DE RESULTADOS",
+const UNITS = [
+  { id: "u1", name: "I. DISEÑO DE SOLUCIONES INNOVADORAS" },
+  { id: "u2", name: "II. GESTIÓN DE PROYECTOS" },
+  { id: "u3", name: "III. INTEGRACIÓN Y ENTREGAS" },
+  { id: "u4", name: "IV. PRESENTACIÓN Y EVALUACIÓN" },
 ];
 
-const SEMANAS = Array.from({ length: 16 }, (_, i) => `Semana ${i + 1}`);
-
-function Counter({ value, max = 400 }: { value: string; max?: number }) {
-  const count = useMemo(() => value.length, [value]);
-  return (
-    <span className="absolute right-3 bottom-2 text-gray-500 text-sm">
-      {count}/{max}
-    </span>
-  );
-}
+const WEEKS = Array.from({ length: 16 }, (_, i) => `Semana ${i + 1}`);
+const MAX_CHARS = 400;
 
 export default function StepWeeks() {
-  const [unidad, setUnidad] = useState(UNIDADES[0]);
-  const [semana, setSemana] = useState(SEMANAS[0]);
+  const [unitId, setUnitId] = useState("u1");
+  const [week, setWeek] = useState(WEEKS[0]);
   const [conceptual, setConceptual] = useState(
-    "El taller y sus objetivos generales. El modelo de trabajo. Planteamiento del problema. El pensamiento de diseño y sus técnicas. Las necesidades del público objetivo y del entorno para entender a los usuarios.",
+    "El taller y sus objetivos generales. El modelo de trabajo. Planteamiento del problema...",
   );
-  const [procedimental, setProcedimental] = useState(
-    "El taller y sus objetivos generales. El modelo de trabajo. Planteamiento del problema. El pensamiento de diseño y sus técnicas. Las necesidades del público objetivo y del entorno para entender a los usuarios.",
+  const [procedural, setProcedural] = useState(
+    "El pensamiento de diseño y sus técnicas. Las necesidades del público objetivo...",
+  );
+
+  const unitLabel = useMemo(
+    () => UNITS.find((u) => u.id === unitId)?.name ?? "",
+    [unitId],
   );
 
   return (
-    <div className="space-y-8">
-      {/* 4. Unidades */}
-      <div className="space-y-3">
-        <h3 className="text-xl font-semibold tracking-tight">4. Unidades</h3>
+    <section className="space-y-6">
+      <h2 className="text-xl font-bold">4. Unidades</h2>
 
-        <div className="relative">
-          <select
-            value={unidad}
-            onChange={(e) => setUnidad(e.target.value)}
-            className="
-              w-full appearance-none border rounded-xl px-4 py-4 pr-12
-              text-lg text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-300
-            "
-          >
-            {UNIDADES.map((u) => (
-              <option key={u} value={u}>{`Unidad: ${u}`}</option>
-            ))}
-          </select>
-
-          <ChevronDown
-            size={20}
-            className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none"
-          />
-        </div>
+      {/* Selector de unidad */}
+      <div className="w-full">
+        <select
+          className="w-full border rounded-lg px-4 py-3 text-gray-700"
+          value={unitId}
+          onChange={(e) => setUnitId(e.target.value)}
+        >
+          {UNITS.map((u) => (
+            <option key={u.id} value={u.id}>
+              Unidad: {u.name}
+            </option>
+          ))}
+        </select>
       </div>
 
-      {/* 4. Semanas */}
-      <div className="space-y-3">
-        <h3 className="text-xl font-semibold tracking-tight">4. Semanas</h3>
-        <p className="text-sm text-gray-600">Selecciona una semana</p>
+      <h3 className="text-xl font-bold">4. Semanas</h3>
+      <label className="block text-sm mb-1">Selecciona una semana</label>
 
-        <div className="relative inline-block">
-          <select
-            value={semana}
-            onChange={(e) => setSemana(e.target.value)}
-            className="
-              appearance-none rounded-full px-5 py-2.5 pr-12
-              bg-black text-white font-semibold
-              focus:outline-none
-            "
-          >
-            {SEMANAS.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <ChevronDown
-            size={18}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-white pointer-events-none"
+      {/* Selector de semana */}
+      <select
+        className="inline-flex items-center gap-2 rounded-full px-4 py-2 border"
+        value={week}
+        onChange={(e) => setWeek(e.target.value)}
+      >
+        {WEEKS.map((w) => (
+          <option key={w}>{w}</option>
+        ))}
+      </select>
+
+      {/* Textareas con contador */}
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="rounded-xl border p-4">
+          <h4 className="font-semibold mb-2">Contenidos conceptuales</h4>
+          <textarea
+            className="w-full min-h-[140px] resize-y border rounded-md px-3 py-2"
+            value={conceptual}
+            maxLength={MAX_CHARS}
+            onChange={(e) => setConceptual(e.target.value)}
           />
-        </div>
-      </div>
-
-      {/* Textareas */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div className="space-y-2">
-          <h4 className="font-semibold text-lg">Contenidos conceptuales</h4>
-          <div className="relative">
-            <textarea
-              rows={9}
-              maxLength={400}
-              value={conceptual}
-              onChange={(e) => setConceptual(e.target.value)}
-              className="w-full border rounded-xl p-4 text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-300"
-              placeholder="El taller y sus objetivos generales..."
-            />
-            <Counter value={conceptual} />
+          <div className="text-right text-sm text-gray-500">
+            {conceptual.length}/{MAX_CHARS}
           </div>
         </div>
 
-        <div className="space-y-2">
-          <h4 className="font-semibold text-lg">Contenidos Procedimentales</h4>
-          <div className="relative">
-            <textarea
-              rows={9}
-              maxLength={400}
-              value={procedimental}
-              onChange={(e) => setProcedimental(e.target.value)}
-              className="w-full border rounded-xl p-4 text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-300"
-              placeholder="El taller y sus objetivos generales..."
-            />
-            <Counter value={procedimental} />
+        <div className="rounded-xl border p-4">
+          <h4 className="font-semibold mb-2">Contenidos procedimentales</h4>
+          <textarea
+            className="w-full min-h-[140px] resize-y border rounded-md px-3 py-2"
+            value={procedural}
+            maxLength={MAX_CHARS}
+            onChange={(e) => setProcedural(e.target.value)}
+          />
+          <div className="text-right text-sm text-gray-500">
+            {procedural.length}/{MAX_CHARS}
           </div>
         </div>
       </div>
-    </div>
+
+      <p className="text-sm text-gray-600">
+        <b>Unidad:</b> {unitLabel} · <b>{week}</b>
+      </p>
+    </section>
   );
 }

--- a/apps/dashboard/src/components/ui/Stepper.tsx
+++ b/apps/dashboard/src/components/ui/Stepper.tsx
@@ -1,43 +1,44 @@
-import { cn } from "../../lib/utils";
+type Base = { onStepClick?: (step: number) => void };
+type LegacyProps = Base & { step: number; total?: number };
+type NewProps = Base & { currentStep: number; totalSteps?: number };
+type Props = LegacyProps | NewProps;
 
-interface StepperProps {
-  currentStep: number;
-  totalSteps: number;
-  onStepClick?: (step: number) => void;
+function isNewProps(p: Props): p is NewProps {
+  return "currentStep" in p || "totalSteps" in p;
 }
 
-export default function Stepper({
-  currentStep,
-  totalSteps,
-  onStepClick,
-}: StepperProps) {
-  const steps = Array.from({ length: totalSteps }, (_, i) => i + 1);
+export default function Stepper(props: Props) {
+  const currentStep = isNewProps(props)
+    ? props.currentStep
+    : (props as LegacyProps).step;
+
+  const total = isNewProps(props)
+    ? (props.totalSteps ?? 5)
+    : ((props as LegacyProps).total ?? 5);
+
+  const onStepClick = props.onStepClick;
+
+  const items = Array.from({ length: total }, (_, i) => i);
 
   return (
-    <div className="flex items-center justify-center mb-8">
-      {steps.map((step, index) => (
-        <div key={step} className="flex items-center">
-          <div
-            className={cn(
-              "w-12 h-12 rounded-full flex items-center justify-center text-lg font-semibold transition-all cursor-pointer",
-              step === currentStep
-                ? "bg-red-500 text-white"
-                : step < currentStep
-                  ? "bg-gray-400 text-white"
-                  : "bg-gray-200 text-gray-600 hover:bg-gray-300",
-            )}
-            onClick={() => onStepClick?.(step)}
+    <div className="flex items-center gap-6 my-6">
+      {items.map((i) => (
+        <div key={i} className="flex items-center gap-6">
+          <button
+            type="button"
+            onClick={() => onStepClick?.(i)}
+            className={[
+              "w-12 h-12 rounded-full flex items-center justify-center border-2 text-lg focus:outline-none",
+              i === currentStep
+                ? "bg-red-600 text-white border-red-600"
+                : "bg-white text-black border-gray-300",
+            ].join(" ")}
+            aria-current={i === currentStep ? "step" : undefined}
+            aria-label={`Paso ${i + 1}`}
           >
-            {step}
-          </div>
-          {index < steps.length - 1 && (
-            <div
-              className={cn(
-                "w-8 h-1 mx-2",
-                step < currentStep ? "bg-gray-400" : "bg-gray-200",
-              )}
-            />
-          )}
+            {i + 1}
+          </button>
+          {i < items.length - 1 && <div className="w-12 h-[2px] bg-gray-300" />}
         </div>
       ))}
     </div>

--- a/apps/dashboard/src/pages/syllabus/[id].tsx
+++ b/apps/dashboard/src/pages/syllabus/[id].tsx
@@ -1,0 +1,6 @@
+import SyllabusWizard from "../../components/SyllabusWizard";
+
+export default function Page() {
+  // por ahora usamos un id fijo; luego vendr� desde la lista de asignaturas
+  return <SyllabusWizard id="demo" />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,17 +22,23 @@
     "apps/dashboard": {
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.13",
+        "@tanstack/react-query": "^5.90.2",
+        "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.544.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.9.1",
+        "react-hook-form": "^7.63.0",
+        "react-router-dom": "^7.9.3",
         "swr": "^2.3.6",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss": "^4.1.13"
+        "tailwindcss": "^4.1.13",
+        "use-debounce": "^10.0.6",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1379,6 +1385,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1854,6 +1872,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
@@ -2123,6 +2147,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2595,6 +2645,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-generator-function/-/async-generator-function-1.0.0.tgz",
+      "integrity": "sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2668,6 +2753,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2795,6 +2893,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -3009,6 +3119,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3038,6 +3157,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3085,6 +3218,51 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -3481,6 +3659,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3493,6 +3707,24 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.0.tgz",
+      "integrity": "sha512-xPypGGincdfyl/AiSGa7GjXLkvld9V7GjZlowup9SHIJnQnHLFiLODCd/DqKOp0PBagbHJ68r1KJI9Mut7m4sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -3513,6 +3745,46 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.1.tgz",
+      "integrity": "sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/git-raw-commits": {
@@ -3575,6 +3847,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3596,6 +3880,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/host": {
@@ -4240,6 +4563,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/meow": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -4275,6 +4607,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4550,6 +4903,12 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4602,6 +4961,22 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.63.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4613,9 +4988,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
-      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4635,12 +5010,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
-      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.1"
+        "react-router": "7.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5204,6 +5579,18 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-debounce": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.6.tgz",
+      "integrity": "sha512-C5OtPyhAZgVoteO9heXMTdW7v/IbFI+8bSVKYCJrSmiWWCLsbUxiBSp4t9v0hNBTGY97bT72ydDIDyGSFWfwXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
@@ -5417,6 +5804,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }


### PR DESCRIPTION
### 📝 Descripción
Maquetación 1:1 del wizard de Sílabo (pasos 1–5) según Figma. **Solo UI**, sin integración a backend.

### ✅ Incluye
- Paso 1: Sumilla
- Paso 2: Unidades / Semanas
- Paso 3: Actividades de aprendizaje
- Paso 4: Bibliográficas
- Paso 5: Electrónicas
- Componente Stepper unificado (acepta step/total y currentStep/totalSteps)

### 🧪 Cómo probar
1) npm install
2) npm run dev --workspace=dashboard
3) Abrir `http://localhost:5173/syllabus/demo` y navegar por los 5 pasos

